### PR TITLE
Kalm test

### DIFF
--- a/careers.py
+++ b/careers.py
@@ -215,6 +215,17 @@ class Monk(Person):
 
 #################################################################
 
+class Priest(Person):
+	def __init__(self, name=''):
+		super().__init__(name=name)
+		self.generate_stats()
+		self.name += ' the Priest'
+
+	def chat(self, other):
+		input(f'{self.name}: Join the church and pay alms.')
+
+#################################################################
+
 if __name__ == '__main__':
 
 	from fileops import load_file

--- a/fileops.py
+++ b/fileops.py
@@ -163,24 +163,24 @@ def get_nested_dict_value(in_dict, *args):
 	else:
 		return value
 
-def print_in_game_text(*args):
-	"""Prints in-game text from 'in_game_text.json'. Location specified by
+def get_in_game_text(*args):
+	"""Gets in-game text from 'in_game_text.json'. Location specified by
 	sequence of keys given in *args.
 
 	Args:
 		*args (strs): Sequence of keys in 'in_game_text.json' 
 			needed to access desired in-game text.
-		E.g.: print_in_game_text('world-text','cave','mouth')
+		E.g.: get_in_game_text('world-text','cave','mouth')
 
 	Returns:
-		None. Prints desired in-game text.
+		out_text (str): Desired in-game-text.
 	"""	
 	try:
 		with open('in_game_text.json') as f:
 			text_dict = json.load(f)
 
 		out_text = get_nested_dict_value(text_dict, *args)
-		print(out_text)
+		return out_text
 
 	except FileNotFoundError:
 		input("ERROR: Couldn't find in_game_text.json")
@@ -188,17 +188,17 @@ def print_in_game_text(*args):
 	except KeyError:
 		input(f'ERROR: Invalid key path in in-game text: {args}')
 		sys.exit(0)
-	except json.JSONDecodeError:
+	'''except json.JSONDecodeError:
 		input('ERROR decoding in_game_text.json')
-		sys.exit(0)
+		sys.exit(0)'''
 
 	
 if __name__ == '__main__':
-	print_in_game_text('world-text','cave','poop')
+	print(get_in_game_text('world-text','cave','poop'))
 	if input('Delve in? ') == 'y':
-		print_in_game_text('world-text','cave','level-1')
+		get_in_game_text('world-text','cave','level-1')
 		if input('Go deeper? ') == 'y':
-			print_in_game_text('world-text','cave','level-2')
+			get_in_game_text('world-text','cave','level-2')
 			if input('Seek the source of the light? ') == 'y':
-				print_in_game_text('world-text','cave','level-3')
+				get_in_game_text('world-text','cave','level-3')
 				print('\nYou are soothed.')

--- a/in_game_text.json
+++ b/in_game_text.json
@@ -7,12 +7,28 @@
             "level-3": "A grotto illuminated by a cool glow."
         },
         "meadow": {
-            "rim": "A broad, shining meadow.", 
-            "center": "You're baking in the sun."
+            "rim": "\nYou stand at the rim of a broad, shining meadow.", 
+            "center": "\nYou're baking in the sun."
         },
         "lonely-mountain": {
             "base": "The mountain rises high above you...",
             "peak": "All the Earth rolls out before you. Only the eagles have seen this sight."
+        },
+        "Kalm": {
+            "outskirts": "\nIn the distance, you see a small town with purple roofs, beset with snow.",
+            "square": "\nYou enter the square of the town of Kalm. The spire of a Gothic church\nlooms over the square. Hanging from its point, an auburn banner flaps in the breeze.",
+            "church": {
+                "entrance": "\nCloudlight filters through the stained glass. It's dim, save for a few candles burning at altars around the room.",
+                "priest-worship-prompt": "\nDouglas the Priest: Have you come to worship with us? (y/n) ",
+                "priest-worship-y": "Wonderful. Please join me at the altar.",
+                "altar": "\nA yellowed cloth covers a simple altar. A candle stands at each end. There is a small dish for alms.",
+                "altar-prompt": "Give alms? (y/n) ",
+                "altar-y": "You drop a coin into the dish.",
+                "altar-n": "Shadows flicker on the coins.",
+                "priest-seek-prompt": "Douglas the Priest: Then, what is it that you seek? (food/shelter/directions/nothing) ",
+                "priest-nothing": "Douglas the Priest: May you return to us with an open heart."
+            }
         }
+
     }
 }

--- a/kalm-test.py
+++ b/kalm-test.py
@@ -1,0 +1,118 @@
+import random
+import fileops
+import printops
+import person
+import careers
+import location
+
+def main():
+    printops.print_title_screen()
+    player = fileops.load_game_or_new_game()
+
+    kalm = location.Location(
+        population = random.randint(20,35),
+        input_name="Kalm",
+        demographics={
+            careers.Peasant: 1
+        },
+        generic_class=careers.Peasant
+    )
+
+    player.location = "Meadow, center"
+
+    print('You start in the meadow.')
+
+    while True:
+
+        if player.location == "Meadow, center":
+            print(fileops.get_in_game_text('world-text','meadow','center'))
+            response = input('Will you leave the meadow? ')
+            if response == 'info':
+                fileops.get_in_game_text('world-text','meadow','center')
+            elif response == 'y':
+                player.location = "Meadow, rim"
+                continue
+            elif response == 'n':
+                continue
+            else:
+                quit()
+
+        elif player.location == "Meadow, rim":
+            print(fileops.get_in_game_text('world-text','meadow','rim'))
+            response = input('Leave the meadow? ')
+            if response == 'y':
+                player.location = 'Kalm, outskirts'
+                continue
+            elif response == 'n':
+                player.location = 'Meadow, center'
+                continue
+            else:
+                quit()
+        
+        elif player.location == "Kalm, outskirts":
+            print(fileops.get_in_game_text('world-text','Kalm','outskirts'))
+            response = input('Draw nearer, or turn back? (nearer/back) ')
+            if response == 'nearer':
+                player.location = 'Kalm, square'
+                continue
+            elif response == 'back':
+                player.location = 'Meadow, rim'
+            else:
+                quit()
+
+        elif player.location == 'Kalm, square':
+            print(fileops.get_in_game_text('world-text','Kalm','square'))
+
+            response = input('Enter the church? ')
+            if response == 'save':
+                fileops.save_file(player)
+            elif response == 'y':
+                player.location = 'Kalm, church, entrance'
+            else:
+                quit()
+
+        elif player.location == 'Kalm, church, entrance':
+            print(fileops.get_in_game_text('world-text','Kalm','church','entrance'))
+
+            priest = careers.Priest(name='Douglas')
+            response = input(
+                fileops.get_in_game_text('world-text','Kalm','church','priest-worship-prompt')
+            )
+
+            if response == 'y':
+                print(fileops.get_in_game_text('world-text','Kalm','church','priest-worship-y'))
+                player.location = 'Kalm, church, altar'
+                continue
+            elif response == 'n':
+                response = input(
+                    fileops.get_in_game_text('world-text','Kalm','church','priest-seek-prompt')
+                    )
+                if response == 'nothing':
+                    input(fileops.get_in_game_text('world-text','Kalm','church','priest-nothing'))
+                    player.location = 'Kalm, square'
+                    continue
+                else:
+                    quit()
+            else:
+                quit()
+
+        elif player.location == 'Kalm, church, altar':
+            print(fileops.get_in_game_text('world-text','Kalm','church','altar'))
+
+            response = input(
+                fileops.get_in_game_text('world-text','Kalm','church','altar-prompt')
+            )
+
+            if response == 'y':
+                input(fileops.get_in_game_text('world-text','Kalm','church','altar-y'))
+            elif response == 'n':
+                input(fileops.get_in_game_text('world-text','Kalm','church','altar-n'))
+            else:
+                quit()
+            
+            player.location = 'Kalm, church, entrance'
+            continue
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
self-contained short exploration of the town of Kalm, its church, and the surrounding meadow.

Major conclusions:
- Need some kind of quest-tracking mechanism. After giving alms, speaking with the priest again gives same options as if it never happened. This needs to be developed so that the priest remembers you, that you did something for him, affect his opinion of you, etc.
- Could be easier to access in-game text. a LOT of `fileops.get_in_game_text('world-text','Kalm'[. . .])`. Would be nice if each location held the subset of text related to it for easier access... not sure how easy this is tho.
- my import syntax is all over the place which is probably why I had so much trouble earlier.
- player location is a good way to track what they should be experiencing. But a single file with a million `if player.location == [...]` is going to make for an enormous, unwieldy main program. Maybe those are all broken into their own files, and the main just imports and runs them all?